### PR TITLE
Fix License URL

### DIFF
--- a/src/renderer/lib/menu.js
+++ b/src/renderer/lib/menu.js
@@ -105,7 +105,7 @@ const template = [
       {
         label: "License",
         click() {
-          openLink("https://github.com/tmdh/laravel-kit/blob/master/LICENSE");
+          openLink("https://github.com/tmdh/laravel-kit/blob/master/license.txt");
         }
       },
       {


### PR DESCRIPTION
Current license URL on the menubar is https://github.com/tmdh/laravel-kit/blob/master/LICENSE, the correct URL based on the repository is https://github.com/tmdh/laravel-kit/blob/master/license.txt